### PR TITLE
responsive menu in pc size

### DIFF
--- a/src/components/Menu.scss
+++ b/src/components/Menu.scss
@@ -1,30 +1,43 @@
 @import '../theme.scss';
 .dropdown-menu {
-  position: fixed;
-  z-index: 10;
-  flex-direction: column;
-  top: 0;
-  left: 50%;
-  width: 100%;
-  height: 0;
-  overflow: hidden;
   transition: all 0.5s;
-  background: white;
-  border-bottom-left-radius: 100%;
-  border-bottom-right-radius: 100%;
-  box-shadow: 0px 10px 20px #ccc;
-  transform: translateX(-50%);
-  -ms-flex-pack: center;
-  justify-content: center;
+  @media #{$mobile-size} {
+    position: fixed;
+    z-index: 10;
+    flex-direction: column;
+    top: 0;
+    left: 50%;
+    width: 100%;
+    height: 0;
+    overflow: hidden;
+    background: white;
+    border-bottom-left-radius: 100%;
+    border-bottom-right-radius: 100%;
+    box-shadow: 0px 10px 20px #ccc;
+    transform: translateX(-50%);
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+  @media #{$pc-size} {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 2rem;
+    font-weight: 700;
+  }
   &.open {
-    height: 35%;
-    padding-top: 110px;    
+    @media #{$mobile-size} {
+      height: 35%;
+      padding-top: 110px;
+    }
   }
   li.menu-item {
     margin-bottom: 1.5rem;
     font-size: 1.1rem;
     text-align: center;
     font-family: 'MuseoSans300', 'sans-serif';
+    @media #{$pc-size} {
+      margin-right: 1rem;
+    }
     a {
       text-decoration: none;
       color: $spearmint-dark;

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -7,3 +7,7 @@ $grey-light: #f2f3f3;
 
 $charcoal-dark: #2b2b2b;
 $charcoal-light: #404041;
+
+// size
+$mobile-size: "screen and (max-width: 549px)";
+$pc-size: "screen and (min-width: 550px)";


### PR DESCRIPTION
This PR only contains the CSS change of the `Menu` component we've talked about. We used media query to make it look different in PC and mobile devices:

> The threshold is 550px btw.

Mobile:
![image](https://user-images.githubusercontent.com/13282699/39335827-997dcdb0-4982-11e8-9dfb-022c5a21dfb2.png)

PC:
![image](https://user-images.githubusercontent.com/13282699/39335832-a027b518-4982-11e8-87db-d6ebe920de86.png)
